### PR TITLE
Speed things up

### DIFF
--- a/theme_unl_composer.json
+++ b/theme_unl_composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "pear-unl/UNL_DWT": "*",
+        "pear-unl/UNL_Cache_Lite" : "*",
         "UNL/PHPUNLTemplates": "dev-master"
     }
 }


### PR DESCRIPTION
By installing the UNL_Cache_Lite lib, page load time decreases from about 5 seconds to 400ms

This way calls to includes on github are cached
