### PR TITLE
Fix login problem where the login link was not pointing to the correct url

### DIFF
--- a/www/themes/unl/html/SiteMaster/Core/Controller.tpl.php
+++ b/www/themes/unl/html/SiteMaster/Core/Controller.tpl.php
@@ -17,7 +17,7 @@ $page->breadcrumbs  = '
 ';
 
 $page->addScriptDeclaration('
-    WDN.jQuery(function() {
+    require(["idm"], function(idm) {
       WDN.setPluginParam("idm", "login", "' . $url . 'auth/unl/");
       WDN.setPluginParam("idm", "logout","' . $url . 'auth/unl/logout/");
     });


### PR DESCRIPTION
use require instead of WDN

In some cases WDN.jQuery(function() { was not firing soon enough
